### PR TITLE
feat(battle): add runtime monster identity foundation

### DIFF
--- a/Client/Assets/Editor/Tests/BattleRuntimeIdentityTests.cs
+++ b/Client/Assets/Editor/Tests/BattleRuntimeIdentityTests.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using MyDefense.Battle.Balance;
+using MyDefense.Battle.Runtime;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace MyDefense.Battle.Tests
+{
+    public sealed class BattleRuntimeIdentityTests
+    {
+        private const BindingFlags PrivateInstance = BindingFlags.Instance | BindingFlags.NonPublic;
+        private const string MonsterPrefabPath = "Assets/Prefabs/Monsters/Monster.prefab";
+        private readonly List<GameObject> _createdObjects = new List<GameObject>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (int index = _createdObjects.Count - 1; index >= 0; index--)
+            {
+                if (_createdObjects[index] != null)
+                    UnityEngine.Object.DestroyImmediate(_createdObjects[index]);
+            }
+            _createdObjects.Clear();
+        }
+
+        [Test]
+        public void SessionContext_ValidatesRequiredFieldsAndIsImmutable()
+        {
+            BattleSessionContext session = Session("session-alpha", 17);
+
+            Assert.That(session.BattleSessionId, Is.EqualTo("session-alpha"));
+            Assert.That(session.StartedAtTick, Is.EqualTo(17));
+            Assert.That(typeof(BattleSessionContext).GetProperty(nameof(BattleSessionContext.BattleSessionId)).CanWrite, Is.False);
+            Assert.Throws<ArgumentException>(() => new BattleSessionContext(" ", "c-v1", "c-hash", "b-v1", "b-hash", 0));
+        }
+
+        [Test]
+        public void RuntimeKeys_AllowSameSequenceInDifferentSessionsWithoutPairCollision()
+        {
+            var first = new BattleRuntimeMonsterKey("session-alpha", 1);
+            var same = new BattleRuntimeMonsterKey("session-alpha", 1);
+            var otherSession = new BattleRuntimeMonsterKey("session-beta", 1);
+
+            Assert.That(first, Is.EqualTo(same));
+            Assert.That(first, Is.Not.EqualTo(otherSession));
+            Assert.That(new HashSet<BattleRuntimeMonsterKey> { first, same, otherSession }.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void SpawnSequence_StartsAtOneIsMonotonicAndDoesNotReuseDiscardedValues()
+        {
+            var issuer = new BattleSpawnSequenceIssuer();
+
+            Assert.That(issuer.IssueNext(), Is.EqualTo(1UL));
+            ulong discardedAfterFailedSpawn = issuer.IssueNext();
+            Assert.That(discardedAfterFailedSpawn, Is.EqualTo(2UL));
+            Assert.That(issuer.IssueNext(), Is.EqualTo(3UL));
+        }
+
+        [Test]
+        public void PlayerIdentityMap_ResolvesDistinctLaneOwnersAndRejectsDuplicates()
+        {
+            var identities = new BattlePlayerIdentityMap("player-alpha", "player-beta");
+
+            Assert.That(identities.TryGetPlayerId(LaneType.Player1Lane, out string player1), Is.True);
+            Assert.That(identities.TryGetPlayerId(LaneType.Player2Lane, out string player2), Is.True);
+            Assert.That(player1, Is.EqualTo("player-alpha"));
+            Assert.That(player2, Is.EqualTo("player-beta"));
+            Assert.That(identities.TryGetPlayerId(LaneType.BossSharedLane, out _), Is.False);
+            Assert.Throws<ArgumentException>(() => new BattlePlayerIdentityMap("same", "same"));
+        }
+
+        [Test]
+        public void RuntimeIdentity_RequiresEachFieldOwnerAndForbidsBossOwner()
+        {
+            BattleSessionContext session = Session("session-alpha");
+
+            Assert.Throws<ArgumentException>(() => Identity(session, 1, BattleMonsterLanePolicy.EACH_FIELD, null));
+            Assert.Throws<ArgumentException>(() => Identity(session, 1, BattleMonsterLanePolicy.BOSS_SHARED, "player-alpha"));
+
+            BattleMonsterRuntimeIdentity boss = Identity(session, 1, BattleMonsterLanePolicy.BOSS_SHARED, null);
+            Assert.That(boss.FieldOwnerPlayerId, Is.Null);
+            Assert.That(boss.RuntimeMonsterId, Is.EqualTo(boss.SpawnSequence));
+        }
+
+        [Test]
+        public void RuntimeContext_InitializesOnceAndRetainsImmutableOwner()
+        {
+            GameObject gameObject = CreateGameObject("Runtime Context Test");
+            BattleMonsterRuntimeContext context = gameObject.AddComponent<BattleMonsterRuntimeContext>();
+            BattleMonsterRuntimeIdentity identity = Identity(
+                Session("session-alpha"),
+                1,
+                BattleMonsterLanePolicy.EACH_FIELD,
+                "player-alpha");
+
+            context.Initialize(identity);
+
+            Assert.That(context.IsInitialized, Is.True);
+            Assert.That(context.Identity.FieldOwnerPlayerId, Is.EqualTo("player-alpha"));
+            Assert.That(typeof(BattleMonsterRuntimeIdentity).GetProperty(nameof(BattleMonsterRuntimeIdentity.FieldOwnerPlayerId)).CanWrite, Is.False);
+            Assert.Throws<InvalidOperationException>(() => context.Initialize(identity));
+        }
+
+        [Test]
+        public void MonsterPrefab_HasExactlyOneUninitializedRuntimeContext()
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(MonsterPrefabPath);
+
+            Assert.That(prefab, Is.Not.Null);
+            BattleMonsterRuntimeContext[] contexts = prefab.GetComponents<BattleMonsterRuntimeContext>();
+            Assert.That(contexts.Length, Is.EqualTo(1));
+            Assert.That(contexts[0].IsInitialized, Is.False);
+        }
+
+        [Test]
+        public void ExecutorSpawn_AssignsUniqueP1P2AndBossRuntimeContexts()
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(MonsterPrefabPath);
+            Assert.That(prefab, Is.Not.Null);
+            BattleWaveExecutor executor = CreateExecutor(prefab, "runtime-spawn-session");
+            var definition = new BattleMonsterDefinition("MONSTER_FIXTURE", "NORMAL", 100f, 2f, "Monster", true);
+            var regularSpawn = new WaveSpawnSpecData(
+                "WAVE_001", 1, BattleLanePolicy.EACH_ACTIVE_PLAYER_LANE, definition.MonsterId, 1, 0f, 0f, 1f, 1f);
+
+            GameObject player1 = InvokeSpawn(executor, LaneType.Player1Lane, definition, regularSpawn);
+            GameObject player2 = InvokeSpawn(executor, LaneType.Player2Lane, definition, regularSpawn);
+            var bossDefinition = new BattleMonsterDefinition("BOSS_FIXTURE", "BOSS", 1000f, 1f, "Monster", false);
+            var bossSpawn = new WaveSpawnSpecData(
+                "WAVE_010", 1, BattleLanePolicy.BOSS_SHARED, bossDefinition.MonsterId, 1, 0f, 0f, 1f, 1f);
+            GameObject boss = InvokeSpawn(executor, LaneType.BossSharedLane, bossDefinition, bossSpawn);
+
+            BattleMonsterRuntimeIdentity p1 = player1.GetComponent<BattleMonsterRuntimeContext>().Identity;
+            BattleMonsterRuntimeIdentity p2 = player2.GetComponent<BattleMonsterRuntimeContext>().Identity;
+            BattleMonsterRuntimeIdentity sharedBoss = boss.GetComponent<BattleMonsterRuntimeContext>().Identity;
+            Assert.That(new[] { p1.RuntimeMonsterId, p2.RuntimeMonsterId, sharedBoss.RuntimeMonsterId }, Is.EqualTo(new ulong[] { 1, 2, 3 }));
+            Assert.That(p1.FieldOwnerPlayerId, Is.EqualTo("fixture-player-alpha"));
+            Assert.That(p2.FieldOwnerPlayerId, Is.EqualTo("fixture-player-beta"));
+            Assert.That(sharedBoss.FieldOwnerPlayerId, Is.Null);
+            Assert.That(sharedBoss.LanePolicy, Is.EqualTo(BattleMonsterLanePolicy.BOSS_SHARED));
+            Assert.That(boss.GetComponents<BattleMonsterRuntimeContext>().Length, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void RegularWaveRoutine_AssignsContextToEveryMonsterInDeterministicLaneOrder()
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(MonsterPrefabPath);
+            Assert.That(prefab, Is.Not.Null);
+            BattleWaveExecutor executor = CreateExecutor(prefab, "runtime-regular-wave-session");
+            SetField(executor, "_currentWaveSpec", new WaveSpecData("WAVE_001", 1, WaveType.REGULAR, 0f, 0f, true));
+            SetField(
+                executor,
+                "_currentWaveSpawns",
+                Array.AsReadOnly(new[]
+                {
+                    new WaveSpawnSpecData(
+                        "WAVE_001",
+                        1,
+                        BattleLanePolicy.EACH_ACTIVE_PLAYER_LANE,
+                        "MONSTER_FIXTURE",
+                        1,
+                        0f,
+                        0f,
+                        1f,
+                        1f)
+                }));
+            Invoke(executor, "BeginWaveExecution", false);
+
+            MethodInfo routineMethod = typeof(BattleWaveExecutor).GetMethod("SpawnRegularWaveRoutine", PrivateInstance);
+            Assert.That(routineMethod, Is.Not.Null);
+            IEnumerator routine = (IEnumerator)routineMethod.Invoke(executor, null);
+            while (routine.MoveNext()) { }
+
+            BattleMonsterRuntimeContext[] contexts = UnityEngine.Object.FindObjectsByType<BattleMonsterRuntimeContext>(
+                    FindObjectsInactive.Exclude,
+                    FindObjectsSortMode.None)
+                .Where(context => context.IsInitialized
+                    && context.Identity.BattleSessionId == "runtime-regular-wave-session")
+                .OrderBy(context => context.Identity.RuntimeMonsterId)
+                .ToArray();
+            foreach (BattleMonsterRuntimeContext context in contexts)
+                _createdObjects.Add(context.gameObject);
+
+            Assert.That(contexts.Length, Is.EqualTo(2));
+            Assert.That(contexts.Select(context => context.Identity.RuntimeMonsterId), Is.EqualTo(new ulong[] { 1, 2 }));
+            Assert.That(contexts[0].Identity.FieldOwnerPlayerId, Is.EqualTo("fixture-player-alpha"));
+            Assert.That(contexts[1].Identity.FieldOwnerPlayerId, Is.EqualTo("fixture-player-beta"));
+        }
+
+        [Test]
+        public void ExecutorSessionReinitialize_RequiresNewIdAndRestartsSequenceAtOne()
+        {
+            GameObject executorObject = CreateGameObject("Session Reinitialize Test");
+            BattleWaveExecutor executor = executorObject.AddComponent<BattleWaveExecutor>();
+            var identities = new BattlePlayerIdentityMap("fixture-player-alpha", "fixture-player-beta");
+            BattleSessionContext first = Session("session-alpha");
+            executor.InitializeSession(first, identities);
+            BattleSpawnSequenceIssuer firstIssuer = GetField<BattleSpawnSequenceIssuer>(executor, "_spawnSequenceIssuer");
+            Assert.That(firstIssuer.IssueNext(), Is.EqualTo(1UL));
+
+            Assert.Throws<InvalidOperationException>(() => executor.InitializeSession(first, identities));
+            executor.InitializeSession(Session("session-beta"), identities);
+
+            BattleSpawnSequenceIssuer secondIssuer = GetField<BattleSpawnSequenceIssuer>(executor, "_spawnSequenceIssuer");
+            Assert.That(secondIssuer, Is.Not.SameAs(firstIssuer));
+            Assert.That(secondIssuer.IssueNext(), Is.EqualTo(1UL));
+        }
+
+        [Test]
+        public void KillDeduplicator_UsesSessionAndRuntimeIdPair()
+        {
+            var deduplicator = new BattleKillDeduplicator();
+            BattleKillAuditRecord first = Kill("session-alpha", 1, "MONSTER", BattleMonsterLanePolicy.EACH_FIELD, "player-alpha");
+            BattleKillAuditRecord duplicate = Kill("session-alpha", 1, "MONSTER", BattleMonsterLanePolicy.EACH_FIELD, "player-alpha");
+            BattleKillAuditRecord otherMonster = Kill("session-alpha", 2, "MONSTER", BattleMonsterLanePolicy.EACH_FIELD, "player-alpha");
+            BattleKillAuditRecord otherSession = Kill("session-beta", 1, "MONSTER", BattleMonsterLanePolicy.EACH_FIELD, "player-alpha");
+            BattleKillAuditRecord boss = Kill("session-alpha", 3, "BOSS", BattleMonsterLanePolicy.BOSS_SHARED, "player-beta");
+
+            Assert.That(deduplicator.TryRegister(first), Is.True);
+            Assert.That(deduplicator.TryRegister(duplicate), Is.False);
+            Assert.That(deduplicator.TryRegister(otherMonster), Is.True);
+            Assert.That(deduplicator.TryRegister(otherSession), Is.True);
+            Assert.That(deduplicator.TryRegister(boss), Is.True);
+            Assert.That(deduplicator.TryRegister(boss), Is.False);
+            Assert.That(deduplicator.Records.Count, Is.EqualTo(4));
+            Assert.That(deduplicator.ProcessedKeys.Count, Is.EqualTo(4));
+            Assert.That(deduplicator.Contains(first.RuntimeKey), Is.True);
+            Assert.That(deduplicator.ProcessedKeys, Is.Not.InstanceOf<HashSet<BattleRuntimeMonsterKey>>());
+        }
+
+        private BattleWaveExecutor CreateExecutor(GameObject prefab, string sessionId)
+        {
+            GameObject executorObject = CreateGameObject("Runtime Identity Executor");
+            BattleWaveExecutor executor = executorObject.AddComponent<BattleWaveExecutor>();
+            GameObject spawnPoint = CreateGameObject("Runtime Identity Spawn Point");
+            SetField(executor, "_spawnPoint", spawnPoint.transform);
+            SetField(executor, "_currentRound", 1);
+            Invoke(
+                executor,
+                "ConfigureBalanceDependenciesForTests",
+                new RuntimeTestBalanceProvider(),
+                new RuntimeTestMonsterProvider(),
+                new RuntimeTestPrefabResolver(prefab));
+            executor.InitializeSession(
+                Session(sessionId),
+                new BattlePlayerIdentityMap("fixture-player-alpha", "fixture-player-beta"));
+            SetField(executor, "_currentRound", 1);
+            return executor;
+        }
+
+        private GameObject InvokeSpawn(
+            BattleWaveExecutor executor,
+            LaneType lane,
+            BattleMonsterDefinition definition,
+            WaveSpawnSpecData spawn)
+        {
+            MethodInfo method = typeof(BattleWaveExecutor).GetMethod("SpawnConfiguredMonster", PrivateInstance);
+            Assert.That(method, Is.Not.Null);
+            object[] arguments = { lane, definition, spawn, 1f, null };
+            Assert.That((bool)method.Invoke(executor, arguments), Is.True);
+            var spawned = (GameObject)arguments[4];
+            Assert.That(spawned, Is.Not.Null);
+            _createdObjects.Add(spawned);
+            return spawned;
+        }
+
+        private GameObject CreateGameObject(string name)
+        {
+            var gameObject = new GameObject(name);
+            _createdObjects.Add(gameObject);
+            return gameObject;
+        }
+
+        private static BattleSessionContext Session(string id, long tick = 0)
+        {
+            return new BattleSessionContext(id, "canonical-v1", "canonical-hash", "battle-v1", "battle-hash", tick);
+        }
+
+        private static BattleMonsterRuntimeIdentity Identity(
+            BattleSessionContext session,
+            ulong id,
+            BattleMonsterLanePolicy policy,
+            string owner)
+        {
+            return new BattleMonsterRuntimeIdentity(session, id, "MONSTER", policy, owner, 1, id);
+        }
+
+        private static BattleKillAuditRecord Kill(
+            string sessionId,
+            ulong runtimeId,
+            string monsterId,
+            BattleMonsterLanePolicy lanePolicy,
+            string killer)
+        {
+            string owner = lanePolicy == BattleMonsterLanePolicy.EACH_FIELD ? "field-owner" : null;
+            return new BattleKillAuditRecord(
+                new BattleRuntimeMonsterKey(sessionId, runtimeId),
+                monsterId,
+                killer,
+                owner,
+                lanePolicy,
+                1,
+                10);
+        }
+
+        private static void SetField(BattleWaveExecutor executor, string fieldName, object value)
+        {
+            FieldInfo field = typeof(BattleWaveExecutor).GetField(fieldName, PrivateInstance);
+            Assert.That(field, Is.Not.Null, fieldName);
+            field.SetValue(executor, value);
+        }
+
+        private static T GetField<T>(BattleWaveExecutor executor, string fieldName)
+        {
+            FieldInfo field = typeof(BattleWaveExecutor).GetField(fieldName, PrivateInstance);
+            Assert.That(field, Is.Not.Null, fieldName);
+            return (T)field.GetValue(executor);
+        }
+
+        private static void Invoke(BattleWaveExecutor executor, string methodName, params object[] arguments)
+        {
+            MethodInfo method = typeof(BattleWaveExecutor).GetMethod(methodName, PrivateInstance);
+            Assert.That(method, Is.Not.Null, methodName);
+            method.Invoke(executor, arguments);
+        }
+
+        private sealed class RuntimeTestMonsterProvider : IMonsterDefinitionProvider
+        {
+            public bool TryGet(string monsterId, out BattleMonsterDefinition definition)
+            {
+                definition = new BattleMonsterDefinition(monsterId, "NORMAL", 100f, 2f, "Monster", true);
+                return true;
+            }
+        }
+
+        private sealed class RuntimeTestPrefabResolver : IBattleMonsterPrefabResolver
+        {
+            private readonly GameObject _prefab;
+            public RuntimeTestPrefabResolver(GameObject prefab) => _prefab = prefab;
+            public bool TryResolve(string prefabKey, out GameObject prefab)
+            {
+                prefab = _prefab;
+                return prefab != null;
+            }
+        }
+
+        private sealed class RuntimeTestBalanceProvider : IBattleBalanceProvider
+        {
+            public int SchemaVersion => 1;
+            public string BalanceVersion => "fixture";
+            public string ContentHash => "fixture";
+            public BattleBalanceCatalog Catalog => null;
+            public bool IsValid => true;
+            public IReadOnlyList<string> ValidationErrors => Array.AsReadOnly(Array.Empty<string>());
+        }
+    }
+}

--- a/Client/Assets/Editor/Tests/BattleRuntimeIdentityTests.cs.meta
+++ b/Client/Assets/Editor/Tests/BattleRuntimeIdentityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 68d8a45a609ce064191ddc49eb95db2a

--- a/Client/Assets/Editor/Tests/BattleSummaryModelTests.cs
+++ b/Client/Assets/Editor/Tests/BattleSummaryModelTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MyDefense.Battle.Runtime;
+using MyDefense.Shared.Contracts;
+using NUnit.Framework;
+
+namespace MyDefense.Battle.Tests
+{
+    public sealed class BattleSummaryModelTests
+    {
+        [Test]
+        public void Summary_AggregatesMonsterPlayerBossAndLaneCounts()
+        {
+            BattleSummary summary = BuildSummary(RecordsInReverseOrder());
+
+            Assert.That(summary.BattleSessionId, Is.EqualTo("summary-session"));
+            Assert.That(summary.Result, Is.EqualTo(MatchState.CLEARED));
+            Assert.That(summary.FinalWave, Is.EqualTo(10));
+            Assert.That(summary.Kills.ByMonster.Select(item => item.MonsterId), Is.EqualTo(new[] { "BOSS", "MONSTER_A", "MONSTER_B" }));
+            Assert.That(summary.Kills.ByMonster.Select(item => item.KillCount), Is.EqualTo(new[] { 1, 2, 1 }));
+            Assert.That(summary.Players.Single(player => player.PlayerId == "player-alpha").Kills, Is.EqualTo(3));
+            Assert.That(summary.Players.Single(player => player.PlayerId == "player-beta").Kills, Is.EqualTo(1));
+            Assert.That(summary.Players.Single(player => player.PlayerId == "player-beta").BossKills, Is.EqualTo(1));
+            Assert.That(summary.Kills.ByLanePolicy.Single(item => item.LanePolicy == BattleMonsterLanePolicy.EACH_FIELD).KillCount, Is.EqualTo(3));
+            Assert.That(summary.Kills.ByLanePolicy.Single(item => item.LanePolicy == BattleMonsterLanePolicy.BOSS_SHARED).KillCount, Is.EqualTo(1));
+            Assert.That(summary.Kills.ByLanePolicy.Sum(item => item.AwardedGold), Is.Zero);
+        }
+
+        [Test]
+        public void Summary_DeduplicatesRuntimeKeyAndCountsBossOnce()
+        {
+            List<BattleKillAuditRecord> records = RecordsInReverseOrder();
+            records.Add(records.Single(record => record.LanePolicy == BattleMonsterLanePolicy.BOSS_SHARED));
+
+            BattleSummary summary = BuildSummary(records);
+
+            Assert.That(summary.Kills.ProcessedRuntimeKeys.Count, Is.EqualTo(4));
+            Assert.That(summary.Players.Sum(player => player.BossKills), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Summary_OutputOrderingIsDeterministicForSameInput()
+        {
+            BattleSummary first = BuildSummary(RecordsInReverseOrder());
+            List<BattleKillAuditRecord> reordered = RecordsInReverseOrder().OrderBy(record => record.MonsterId).ToList();
+            BattleSummary second = BuildSummary(reordered);
+
+            Assert.That(Signature(first), Is.EqualTo(Signature(second)));
+            Assert.That(first.Players.Select(player => player.PlayerId), Is.EqualTo(new[] { "player-alpha", "player-beta" }));
+            Assert.That(first.Kills.ProcessedRuntimeKeys.Select(key => key.RuntimeMonsterId), Is.EqualTo(new ulong[] { 1, 2, 3, 4 }));
+        }
+
+        [Test]
+        public void Summary_CollectionsCannotBeMutatedExternally()
+        {
+            BattleSummary summary = BuildSummary(RecordsInReverseOrder());
+
+            Assert.Throws<NotSupportedException>(() => ((IList<BattlePlayerSummary>)summary.Players).Clear());
+            Assert.Throws<NotSupportedException>(() => ((IList<BattleMonsterKillSummary>)summary.Kills.ByMonster).Clear());
+            Assert.Throws<NotSupportedException>(() => ((IList<BattleRuntimeMonsterKey>)summary.Kills.ProcessedRuntimeKeys).Clear());
+            Assert.Throws<NotSupportedException>(() => ((IList<BattleLaneKillSummary>)summary.Kills.ByLanePolicy).Clear());
+        }
+
+        [Test]
+        public void Summary_GoldFieldsAreInputOnlyAndNoSettlementSideEffectOccurs()
+        {
+            BattleSummary summary = BuildSummary(RecordsInReverseOrder());
+            BattlePlayerSummary alpha = summary.Players.Single(player => player.PlayerId == "player-alpha");
+
+            Assert.That(alpha.InGameGoldEarned, Is.EqualTo(25));
+            Assert.That(alpha.InGameGoldSpent, Is.EqualTo(7));
+            Assert.That(summary.Kills.ByLanePolicy.All(item => item.AwardedGold == 0), Is.True);
+        }
+
+        private static BattleSummary BuildSummary(IEnumerable<BattleKillAuditRecord> records)
+        {
+            var session = new BattleSessionContext(
+                "summary-session",
+                "canonical-v1",
+                "canonical-hash",
+                "battle-v1",
+                "battle-hash",
+                100);
+            var players = new[]
+            {
+                new BattlePlayerSummarySeed("player-beta", true, 9, 10, 3),
+                new BattlePlayerSummarySeed("player-alpha", false, null, 25, 7)
+            };
+            return BattleSummaryBuilder.Build(session, MatchState.CLEARED, 10, players, records);
+        }
+
+        private static List<BattleKillAuditRecord> RecordsInReverseOrder()
+        {
+            return new List<BattleKillAuditRecord>
+            {
+                Kill(4, "BOSS", "player-beta", BattleMonsterLanePolicy.BOSS_SHARED),
+                Kill(3, "MONSTER_B", "player-alpha", BattleMonsterLanePolicy.EACH_FIELD),
+                Kill(2, "MONSTER_A", "player-alpha", BattleMonsterLanePolicy.EACH_FIELD),
+                Kill(1, "MONSTER_A", "player-alpha", BattleMonsterLanePolicy.EACH_FIELD)
+            };
+        }
+
+        private static BattleKillAuditRecord Kill(
+            ulong runtimeId,
+            string monsterId,
+            string killer,
+            BattleMonsterLanePolicy lanePolicy)
+        {
+            return new BattleKillAuditRecord(
+                new BattleRuntimeMonsterKey("summary-session", runtimeId),
+                monsterId,
+                killer,
+                lanePolicy == BattleMonsterLanePolicy.EACH_FIELD ? "field-owner" : null,
+                lanePolicy,
+                runtimeId == 4 ? 10 : 1,
+                (long)runtimeId * 10);
+        }
+
+        private static string Signature(BattleSummary summary)
+        {
+            return string.Join(
+                "|",
+                summary.Players.Select(player => player.PlayerId + ":" + player.Kills + ":" + player.BossKills)
+                    .Concat(summary.Kills.ByMonster.Select(item => item.MonsterId + ":" + item.KillCount))
+                    .Concat(summary.Kills.ProcessedRuntimeKeys.Select(key => key.ToString()))
+                    .Concat(summary.Kills.ByLanePolicy.Select(item => item.LanePolicy + ":" + item.KillCount)));
+        }
+    }
+}

--- a/Client/Assets/Editor/Tests/BattleSummaryModelTests.cs.meta
+++ b/Client/Assets/Editor/Tests/BattleSummaryModelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a9f91dc0f1d535f478ba326bbb1021dd

--- a/Client/Assets/Editor/Tests/BattleWaveExecutorBalanceTests.cs
+++ b/Client/Assets/Editor/Tests/BattleWaveExecutorBalanceTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using MyDefense.Battle;
 using MyDefense.Battle.Balance;
+using MyDefense.Battle.Runtime;
 using MyDefense.Shared.Contracts;
 using NUnit.Framework;
 using UnityEditor;
@@ -27,6 +28,7 @@ namespace MyDefense.Battle.Tests
         private IMonsterDefinitionProvider _monsterDefinitions;
         private IBattleMonsterPrefabResolver _prefabResolver;
         private readonly List<GameObject> _spawnedObjects = new List<GameObject>();
+        private int _sessionNumber;
 
         [SetUp]
         public void SetUp()
@@ -53,7 +55,7 @@ namespace MyDefense.Battle.Tests
             SetField("_spawnPoint", _spawnPointObject.transform);
             SetField("_totalMonsterGoal", 100);
             Configure(new ResourcesBattleBalanceProvider(_monsterDefinitions, EmptyBattleAlienIdProvider.Instance));
-            _executor.InitializeSession();
+            InitializeRuntimeSession();
         }
 
         [TearDown]
@@ -100,7 +102,7 @@ namespace MyDefense.Battle.Tests
                 monsters: monsters,
                 aliens: BattleBalanceTestFixture.Aliens());
             Configure(provider, monsters, new RejectingPrefabResolver());
-            _executor.InitializeSession();
+            InitializeRuntimeSession();
             SetField("_currentRound", 1);
 
             Assert.That(Invoke<bool>("TryBeginNextWave"), Is.True);
@@ -271,7 +273,7 @@ namespace MyDefense.Battle.Tests
         public void InvalidProvider_ReportsAllErrorsOnceAndFaultsExecutor()
         {
             Configure(new InvalidBalanceProvider("validation one", "validation two"));
-            _executor.InitializeSession();
+            InitializeRuntimeSession();
             LogAssert.Expect(LogType.Error, new Regex("validation one[\\s\\S]*validation two"));
 
             Assert.That(Invoke<bool>("EnsureBalanceInitialized"), Is.False);
@@ -287,7 +289,7 @@ namespace MyDefense.Battle.Tests
                 new ResourcesBattleBalanceProvider(_monsterDefinitions, EmptyBattleAlienIdProvider.Instance),
                 _monsterDefinitions,
                 new RejectingPrefabResolver());
-            _executor.InitializeSession();
+            InitializeRuntimeSession();
             BeginActualRoundOne();
             LogAssert.Expect(LogType.Error, new Regex("Cannot resolve prefabKey"));
 
@@ -303,7 +305,7 @@ namespace MyDefense.Battle.Tests
                 new ResourcesBattleBalanceProvider(_monsterDefinitions, EmptyBattleAlienIdProvider.Instance),
                 new RejectingMonsterProvider(),
                 _prefabResolver);
-            _executor.InitializeSession();
+            InitializeRuntimeSession();
             BeginActualRoundOne();
             LogAssert.Expect(LogType.Error, new Regex("unknown monsterId 'MONSTER_NORMAL_DEFAULT'"));
 
@@ -333,7 +335,7 @@ namespace MyDefense.Battle.Tests
                 provider,
                 monsters,
                 new ExplicitBattleMonsterPrefabResolver("Monster", _monsterPrefab));
-            _executor.InitializeSession();
+            InitializeRuntimeSession();
             Assert.That(Invoke<bool>("TryBeginNextWave"), Is.True);
             LogAssert.Expect(LogType.Error, new Regex("Cannot resolve prefabKey 'Missing'"));
 
@@ -354,7 +356,7 @@ namespace MyDefense.Battle.Tests
                 new ResourcesBattleBalanceProvider(_monsterDefinitions, EmptyBattleAlienIdProvider.Instance),
                 _monsterDefinitions,
                 new ExplicitBattleMonsterPrefabResolver("Monster", invalid));
-            _executor.InitializeSession();
+            InitializeRuntimeSession();
             BeginActualRoundOne();
             LogAssert.Expect(LogType.Error, new Regex("exactly one BattleMonsterMovement"));
 
@@ -373,7 +375,7 @@ namespace MyDefense.Battle.Tests
                 new ResourcesBattleBalanceProvider(_monsterDefinitions, EmptyBattleAlienIdProvider.Instance),
                 _monsterDefinitions,
                 new ExplicitBattleMonsterPrefabResolver("Monster", invalid));
-            _executor.InitializeSession();
+            InitializeRuntimeSession();
             BeginActualRoundOne();
             LogAssert.Expect(LogType.Error, new Regex("must contain MonsterStat"));
 
@@ -398,6 +400,20 @@ namespace MyDefense.Battle.Tests
                 provider,
                 monsters ?? _monsterDefinitions,
                 resolver ?? _prefabResolver);
+        }
+
+        private void InitializeRuntimeSession()
+        {
+            _sessionNumber++;
+            _executor.InitializeSession(
+                new BattleSessionContext(
+                    "executor-fixture-session-" + _sessionNumber,
+                    "fixture-canonical-v1",
+                    "fixture-canonical-hash",
+                    "fixture-battle-v1",
+                    "fixture-battle-hash",
+                    _sessionNumber),
+                new BattlePlayerIdentityMap("fixture-player-alpha", "fixture-player-beta"));
         }
 
         private void AssertFaultedAndStopped()

--- a/Client/Assets/Editor/Tests/BattleWaveExecutorStateTests.cs
+++ b/Client/Assets/Editor/Tests/BattleWaveExecutorStateTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using MyDefense.Battle;
 using MyDefense.Battle.Balance;
+using MyDefense.Battle.Runtime;
 using MyDefense.Shared.Contracts;
 using NUnit.Framework;
 using UnityEditor;
@@ -22,6 +23,7 @@ public class BattleWaveExecutorStateTests
     private GameObject _executorObject;
     private BattleWaveExecutor _executor;
     private GameObject _bossObject;
+    private int _sessionNumber;
 
     [SetUp]
     public void SetUp()
@@ -34,7 +36,7 @@ public class BattleWaveExecutorStateTests
             monsters,
             new StateTestPrefabResolver());
         SetField("_totalMonsterGoal", 1);
-        _executor.InitializeSession();
+        InitializeRuntimeSession();
     }
 
     [TearDown]
@@ -174,7 +176,7 @@ public class BattleWaveExecutorStateTests
     {
         ActivateBoss();
 
-        _executor.InitializeSession();
+        InitializeRuntimeSession();
 
         Assert.That(_bossObject == null, Is.True);
         Assert.That(GetField("_currentBossInstance"), Is.Null);
@@ -481,6 +483,20 @@ public class BattleWaveExecutorStateTests
         IBattleMonsterPrefabResolver resolver)
     {
         Invoke("ConfigureBalanceDependenciesForTests", provider, monsters, resolver);
+    }
+
+    private void InitializeRuntimeSession()
+    {
+        _sessionNumber++;
+        _executor.InitializeSession(
+            new BattleSessionContext(
+                "state-fixture-session-" + _sessionNumber,
+                "fixture-canonical-v1",
+                "fixture-canonical-hash",
+                "fixture-battle-v1",
+                "fixture-battle-hash",
+                _sessionNumber),
+            new BattlePlayerIdentityMap("fixture-player-alpha", "fixture-player-beta"));
     }
 
     private static Scene GetBattleScene(out bool openedByTest)

--- a/Client/Assets/Prefabs/Monsters/Monster.prefab
+++ b/Client/Assets/Prefabs/Monsters/Monster.prefab
@@ -473,6 +473,7 @@ GameObject:
   - component: {fileID: -5900148494275695505}
   - component: {fileID: 7362284352776375731}
   - component: {fileID: 4201090289808750039}
+  - component: {fileID: 9030318921090463371}
   m_Layer: 0
   m_Name: Monster
   m_TagString: Monster
@@ -621,6 +622,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MyDefense.Battle.BattleMonsterMovement
   _laneType: 0
   _speed: 5
+--- !u!114 &9030318921090463371
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7463564369751362190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 34e6fde965d7aa544b120fff8abd029e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MyDefense.Battle.Runtime.BattleMonsterRuntimeContext
 --- !u!1 &8188314502259905187
 GameObject:
   m_ObjectHideFlags: 0

--- a/Client/Assets/Scripts/Battle/Runtime.meta
+++ b/Client/Assets/Scripts/Battle/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82f51b80049a2184f854f41ec9d9ce22
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Battle/Runtime/BattleKillDeduplicator.cs
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleKillDeduplicator.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+
+namespace MyDefense.Battle.Runtime
+{
+    public sealed class BattleKillAuditRecord
+    {
+        public BattleRuntimeMonsterKey RuntimeKey { get; }
+        public string BattleSessionId => RuntimeKey.BattleSessionId;
+        public ulong RuntimeMonsterId => RuntimeKey.RuntimeMonsterId;
+        public string MonsterId { get; }
+        public string KillerPlayerId { get; }
+        public string FieldOwnerPlayerId { get; }
+        public BattleMonsterLanePolicy LanePolicy { get; }
+        public int SpawnWave { get; }
+        public long KilledAtTick { get; }
+
+        public BattleKillAuditRecord(
+            BattleRuntimeMonsterKey runtimeKey,
+            string monsterId,
+            string killerPlayerId,
+            string fieldOwnerPlayerId,
+            BattleMonsterLanePolicy lanePolicy,
+            int spawnWave,
+            long killedAtTick)
+        {
+            if (string.IsNullOrWhiteSpace(runtimeKey.BattleSessionId) || runtimeKey.RuntimeMonsterId == 0)
+                throw new ArgumentException("A valid runtime monster key is required.", nameof(runtimeKey));
+            if (spawnWave < 1) throw new ArgumentOutOfRangeException(nameof(spawnWave));
+            if (killedAtTick < 0) throw new ArgumentOutOfRangeException(nameof(killedAtTick));
+
+            RuntimeKey = runtimeKey;
+            MonsterId = BattleSessionContext.RequireText(monsterId, nameof(monsterId));
+            KillerPlayerId = BattleSessionContext.RequireText(killerPlayerId, nameof(killerPlayerId));
+            LanePolicy = lanePolicy;
+            if (lanePolicy == BattleMonsterLanePolicy.EACH_FIELD)
+                FieldOwnerPlayerId = BattleSessionContext.RequireText(fieldOwnerPlayerId, nameof(fieldOwnerPlayerId));
+            else if (lanePolicy == BattleMonsterLanePolicy.BOSS_SHARED)
+            {
+                if (!string.IsNullOrEmpty(fieldOwnerPlayerId))
+                    throw new ArgumentException("BOSS_SHARED kills cannot have a field owner.", nameof(fieldOwnerPlayerId));
+                FieldOwnerPlayerId = null;
+            }
+            else
+                throw new ArgumentOutOfRangeException(nameof(lanePolicy));
+
+            SpawnWave = spawnWave;
+            KilledAtTick = killedAtTick;
+        }
+    }
+
+    public sealed class BattleKillDeduplicator
+    {
+        private readonly HashSet<BattleRuntimeMonsterKey> _processedKeys = new HashSet<BattleRuntimeMonsterKey>();
+        private readonly List<BattleKillAuditRecord> _records = new List<BattleKillAuditRecord>();
+        private readonly IReadOnlyList<BattleKillAuditRecord> _recordsView;
+
+        public BattleKillDeduplicator()
+        {
+            _recordsView = _records.AsReadOnly();
+        }
+
+        public IReadOnlyCollection<BattleRuntimeMonsterKey> ProcessedKeys
+        {
+            get
+            {
+                var snapshot = new List<BattleRuntimeMonsterKey>(_processedKeys);
+                snapshot.Sort();
+                return snapshot.AsReadOnly();
+            }
+        }
+
+        public IReadOnlyList<BattleKillAuditRecord> Records => _recordsView;
+
+        public bool TryRegister(BattleKillAuditRecord record)
+        {
+            if (record == null) throw new ArgumentNullException(nameof(record));
+            if (!_processedKeys.Add(record.RuntimeKey)) return false;
+
+            _records.Add(record);
+            return true;
+        }
+
+        public bool Contains(BattleRuntimeMonsterKey key) => _processedKeys.Contains(key);
+    }
+}

--- a/Client/Assets/Scripts/Battle/Runtime/BattleKillDeduplicator.cs.meta
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleKillDeduplicator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f68aa92b89020584c9b987d03498769c

--- a/Client/Assets/Scripts/Battle/Runtime/BattleMonsterIdentity.cs
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleMonsterIdentity.cs
@@ -1,0 +1,156 @@
+using System;
+
+namespace MyDefense.Battle.Runtime
+{
+    public enum BattleMonsterLanePolicy
+    {
+        EACH_FIELD,
+        BOSS_SHARED
+    }
+
+    public readonly struct BattleRuntimeMonsterKey : IEquatable<BattleRuntimeMonsterKey>, IComparable<BattleRuntimeMonsterKey>
+    {
+        public string BattleSessionId { get; }
+        public ulong RuntimeMonsterId { get; }
+
+        public BattleRuntimeMonsterKey(string battleSessionId, ulong runtimeMonsterId)
+        {
+            BattleSessionId = BattleSessionContext.RequireText(battleSessionId, nameof(battleSessionId));
+            if (runtimeMonsterId == 0)
+                throw new ArgumentOutOfRangeException(nameof(runtimeMonsterId), "Runtime monster ID starts at one.");
+
+            RuntimeMonsterId = runtimeMonsterId;
+        }
+
+        public bool Equals(BattleRuntimeMonsterKey other)
+        {
+            return RuntimeMonsterId == other.RuntimeMonsterId
+                && string.Equals(BattleSessionId, other.BattleSessionId, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj) => obj is BattleRuntimeMonsterKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int sessionHash = BattleSessionId == null ? 0 : StringComparer.Ordinal.GetHashCode(BattleSessionId);
+                return (sessionHash * 397) ^ RuntimeMonsterId.GetHashCode();
+            }
+        }
+
+        public int CompareTo(BattleRuntimeMonsterKey other)
+        {
+            int sessionOrder = string.Compare(BattleSessionId, other.BattleSessionId, StringComparison.Ordinal);
+            return sessionOrder != 0 ? sessionOrder : RuntimeMonsterId.CompareTo(other.RuntimeMonsterId);
+        }
+
+        public override string ToString() => BattleSessionId + ":" + RuntimeMonsterId;
+    }
+
+    public sealed class BattleSpawnSequenceIssuer
+    {
+        private ulong _nextSequence = 1;
+
+        public ulong IssueNext()
+        {
+            if (_nextSequence == 0)
+                throw new OverflowException("Battle spawn sequence is exhausted.");
+
+            ulong issued = _nextSequence;
+            _nextSequence = issued == ulong.MaxValue ? 0 : issued + 1;
+            return issued;
+        }
+    }
+
+    public interface IBattlePlayerIdentityProvider
+    {
+        bool TryGetPlayerId(LaneType lane, out string playerId);
+    }
+
+    public sealed class BattlePlayerIdentityMap : IBattlePlayerIdentityProvider
+    {
+        private readonly string _player1Id;
+        private readonly string _player2Id;
+
+        public BattlePlayerIdentityMap(string player1Id, string player2Id)
+        {
+            _player1Id = BattleSessionContext.RequireText(player1Id, nameof(player1Id));
+            _player2Id = BattleSessionContext.RequireText(player2Id, nameof(player2Id));
+            if (string.Equals(_player1Id, _player2Id, StringComparison.Ordinal))
+                throw new ArgumentException("Player identities must be distinct.", nameof(player2Id));
+        }
+
+        public bool TryGetPlayerId(LaneType lane, out string playerId)
+        {
+            switch (lane)
+            {
+                case LaneType.Player1Lane:
+                    playerId = _player1Id;
+                    return true;
+                case LaneType.Player2Lane:
+                    playerId = _player2Id;
+                    return true;
+                default:
+                    playerId = null;
+                    return false;
+            }
+        }
+    }
+
+    public sealed class BattleMonsterRuntimeIdentity
+    {
+        public BattleSessionContext Session { get; }
+        public string BattleSessionId => Session.BattleSessionId;
+        public ulong RuntimeMonsterId { get; }
+        public string MonsterId { get; }
+        public BattleMonsterLanePolicy LanePolicy { get; }
+        public string FieldOwnerPlayerId { get; }
+        public int SpawnWave { get; }
+        public ulong SpawnSequence { get; }
+        public string CanonicalBalanceVersion => Session.CanonicalBalanceVersion;
+        public string CanonicalContentHash => Session.CanonicalContentHash;
+        public BattleRuntimeMonsterKey RuntimeKey => new BattleRuntimeMonsterKey(BattleSessionId, RuntimeMonsterId);
+
+        public BattleMonsterRuntimeIdentity(
+            BattleSessionContext session,
+            ulong runtimeMonsterId,
+            string monsterId,
+            BattleMonsterLanePolicy lanePolicy,
+            string fieldOwnerPlayerId,
+            int spawnWave,
+            ulong spawnSequence)
+        {
+            Session = session ?? throw new ArgumentNullException(nameof(session));
+            if (runtimeMonsterId == 0)
+                throw new ArgumentOutOfRangeException(nameof(runtimeMonsterId));
+            if (spawnSequence == 0)
+                throw new ArgumentOutOfRangeException(nameof(spawnSequence));
+            if (runtimeMonsterId != spawnSequence)
+                throw new ArgumentException("Runtime monster ID must equal its spawn sequence.", nameof(runtimeMonsterId));
+            if (spawnWave < 1)
+                throw new ArgumentOutOfRangeException(nameof(spawnWave));
+
+            MonsterId = BattleSessionContext.RequireText(monsterId, nameof(monsterId));
+            LanePolicy = lanePolicy;
+            if (lanePolicy == BattleMonsterLanePolicy.EACH_FIELD)
+            {
+                FieldOwnerPlayerId = BattleSessionContext.RequireText(fieldOwnerPlayerId, nameof(fieldOwnerPlayerId));
+            }
+            else if (lanePolicy == BattleMonsterLanePolicy.BOSS_SHARED)
+            {
+                if (!string.IsNullOrEmpty(fieldOwnerPlayerId))
+                    throw new ArgumentException("BOSS_SHARED monsters cannot have a field owner.", nameof(fieldOwnerPlayerId));
+                FieldOwnerPlayerId = null;
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(lanePolicy));
+            }
+
+            RuntimeMonsterId = runtimeMonsterId;
+            SpawnWave = spawnWave;
+            SpawnSequence = spawnSequence;
+        }
+    }
+}

--- a/Client/Assets/Scripts/Battle/Runtime/BattleMonsterIdentity.cs.meta
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleMonsterIdentity.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b57bba83b21a3184397c986537391e23

--- a/Client/Assets/Scripts/Battle/Runtime/BattleMonsterRuntimeContext.cs
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleMonsterRuntimeContext.cs
@@ -1,0 +1,31 @@
+using System;
+using UnityEngine;
+
+namespace MyDefense.Battle.Runtime
+{
+    [DisallowMultipleComponent]
+    public sealed class BattleMonsterRuntimeContext : MonoBehaviour
+    {
+        private BattleMonsterRuntimeIdentity _identity;
+
+        public bool IsInitialized => _identity != null;
+
+        public BattleMonsterRuntimeIdentity Identity
+        {
+            get
+            {
+                if (_identity == null)
+                    throw new InvalidOperationException("Monster runtime context has not been initialized.");
+                return _identity;
+            }
+        }
+
+        public void Initialize(BattleMonsterRuntimeIdentity identity)
+        {
+            if (_identity != null)
+                throw new InvalidOperationException("Monster runtime context can only be initialized once.");
+
+            _identity = identity ?? throw new ArgumentNullException(nameof(identity));
+        }
+    }
+}

--- a/Client/Assets/Scripts/Battle/Runtime/BattleMonsterRuntimeContext.cs.meta
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleMonsterRuntimeContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 34e6fde965d7aa544b120fff8abd029e

--- a/Client/Assets/Scripts/Battle/Runtime/BattleSessionContext.cs
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleSessionContext.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace MyDefense.Battle.Runtime
+{
+    public sealed class BattleSessionContext
+    {
+        public string BattleSessionId { get; }
+        public string CanonicalBalanceVersion { get; }
+        public string CanonicalContentHash { get; }
+        public string BattleContentVersion { get; }
+        public string BattleContentHash { get; }
+        public long StartedAtTick { get; }
+
+        public BattleSessionContext(
+            string battleSessionId,
+            string canonicalBalanceVersion,
+            string canonicalContentHash,
+            string battleContentVersion,
+            string battleContentHash,
+            long startedAtTick)
+        {
+            BattleSessionId = RequireText(battleSessionId, nameof(battleSessionId));
+            CanonicalBalanceVersion = RequireText(canonicalBalanceVersion, nameof(canonicalBalanceVersion));
+            CanonicalContentHash = RequireText(canonicalContentHash, nameof(canonicalContentHash));
+            BattleContentVersion = RequireText(battleContentVersion, nameof(battleContentVersion));
+            BattleContentHash = RequireText(battleContentHash, nameof(battleContentHash));
+            if (startedAtTick < 0)
+                throw new ArgumentOutOfRangeException(nameof(startedAtTick), "Session start tick cannot be negative.");
+
+            StartedAtTick = startedAtTick;
+        }
+
+        internal static string RequireText(string value, string parameterName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("A non-empty value is required.", parameterName);
+
+            return value;
+        }
+    }
+}

--- a/Client/Assets/Scripts/Battle/Runtime/BattleSessionContext.cs.meta
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleSessionContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1dcb056b83a03442b553c1ac289e1af

--- a/Client/Assets/Scripts/Battle/Runtime/BattleSummary.cs
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleSummary.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MyDefense.Shared.Contracts;
+
+namespace MyDefense.Battle.Runtime
+{
+    public sealed class BattlePlayerSummarySeed
+    {
+        public string PlayerId { get; }
+        public bool Eliminated { get; }
+        public int? EliminatedWave { get; }
+        public int InGameGoldEarned { get; }
+        public int InGameGoldSpent { get; }
+
+        public BattlePlayerSummarySeed(
+            string playerId,
+            bool eliminated,
+            int? eliminatedWave,
+            int inGameGoldEarned,
+            int inGameGoldSpent)
+        {
+            PlayerId = BattleSessionContext.RequireText(playerId, nameof(playerId));
+            if (eliminated && (!eliminatedWave.HasValue || eliminatedWave.Value < 1))
+                throw new ArgumentException("Eliminated players require a positive eliminated wave.", nameof(eliminatedWave));
+            if (!eliminated && eliminatedWave.HasValue)
+                throw new ArgumentException("Active players cannot have an eliminated wave.", nameof(eliminatedWave));
+            if (inGameGoldEarned < 0) throw new ArgumentOutOfRangeException(nameof(inGameGoldEarned));
+            if (inGameGoldSpent < 0) throw new ArgumentOutOfRangeException(nameof(inGameGoldSpent));
+
+            Eliminated = eliminated;
+            EliminatedWave = eliminatedWave;
+            InGameGoldEarned = inGameGoldEarned;
+            InGameGoldSpent = inGameGoldSpent;
+        }
+    }
+
+    public sealed class BattlePlayerSummary
+    {
+        public string PlayerId { get; }
+        public bool Eliminated { get; }
+        public int? EliminatedWave { get; }
+        public int Kills { get; }
+        public int BossKills { get; }
+        public int InGameGoldEarned { get; }
+        public int InGameGoldSpent { get; }
+
+        internal BattlePlayerSummary(BattlePlayerSummarySeed seed, int kills, int bossKills)
+        {
+            PlayerId = seed.PlayerId;
+            Eliminated = seed.Eliminated;
+            EliminatedWave = seed.EliminatedWave;
+            Kills = kills;
+            BossKills = bossKills;
+            InGameGoldEarned = seed.InGameGoldEarned;
+            InGameGoldSpent = seed.InGameGoldSpent;
+        }
+    }
+
+    public sealed class BattleMonsterKillSummary
+    {
+        public string MonsterId { get; }
+        public int KillCount { get; }
+
+        internal BattleMonsterKillSummary(string monsterId, int killCount)
+        {
+            MonsterId = monsterId;
+            KillCount = killCount;
+        }
+    }
+
+    public sealed class BattleLaneKillSummary
+    {
+        public BattleMonsterLanePolicy LanePolicy { get; }
+        public int KillCount { get; }
+        public int AwardedGold { get; }
+
+        internal BattleLaneKillSummary(BattleMonsterLanePolicy lanePolicy, int killCount)
+        {
+            LanePolicy = lanePolicy;
+            KillCount = killCount;
+            AwardedGold = 0;
+        }
+    }
+
+    public sealed class BattleKillSummary
+    {
+        public IReadOnlyList<BattleMonsterKillSummary> ByMonster { get; }
+        public IReadOnlyList<BattleRuntimeMonsterKey> ProcessedRuntimeKeys { get; }
+        public IReadOnlyList<BattleLaneKillSummary> ByLanePolicy { get; }
+
+        internal BattleKillSummary(
+            IReadOnlyList<BattleMonsterKillSummary> byMonster,
+            IReadOnlyList<BattleRuntimeMonsterKey> processedRuntimeKeys,
+            IReadOnlyList<BattleLaneKillSummary> byLanePolicy)
+        {
+            ByMonster = byMonster;
+            ProcessedRuntimeKeys = processedRuntimeKeys;
+            ByLanePolicy = byLanePolicy;
+        }
+    }
+
+    public sealed class BattleSummary
+    {
+        public string BattleSessionId { get; }
+        public string CanonicalBalanceVersion { get; }
+        public string CanonicalContentHash { get; }
+        public MatchState Result { get; }
+        public int FinalWave { get; }
+        public IReadOnlyList<BattlePlayerSummary> Players { get; }
+        public BattleKillSummary Kills { get; }
+
+        internal BattleSummary(
+            BattleSessionContext session,
+            MatchState result,
+            int finalWave,
+            IReadOnlyList<BattlePlayerSummary> players,
+            BattleKillSummary kills)
+        {
+            BattleSessionId = session.BattleSessionId;
+            CanonicalBalanceVersion = session.CanonicalBalanceVersion;
+            CanonicalContentHash = session.CanonicalContentHash;
+            Result = result;
+            FinalWave = finalWave;
+            Players = players;
+            Kills = kills;
+        }
+    }
+
+    public static class BattleSummaryBuilder
+    {
+        public static BattleSummary Build(
+            BattleSessionContext session,
+            MatchState result,
+            int finalWave,
+            IEnumerable<BattlePlayerSummarySeed> playerSeeds,
+            IEnumerable<BattleKillAuditRecord> killRecords)
+        {
+            if (session == null) throw new ArgumentNullException(nameof(session));
+            if (result == MatchState.RUNNING) throw new ArgumentException("A final summary requires a terminal result.", nameof(result));
+            if (finalWave < 0) throw new ArgumentOutOfRangeException(nameof(finalWave));
+            if (playerSeeds == null) throw new ArgumentNullException(nameof(playerSeeds));
+            if (killRecords == null) throw new ArgumentNullException(nameof(killRecords));
+
+            List<BattlePlayerSummarySeed> seeds = playerSeeds.OrderBy(seed => seed.PlayerId, StringComparer.Ordinal).ToList();
+            if (seeds.Count == 0) throw new ArgumentException("At least one player summary is required.", nameof(playerSeeds));
+            if (seeds.Select(seed => seed.PlayerId).Distinct(StringComparer.Ordinal).Count() != seeds.Count)
+                throw new ArgumentException("Player summary IDs must be unique.", nameof(playerSeeds));
+
+            var uniqueRecords = new Dictionary<BattleRuntimeMonsterKey, BattleKillAuditRecord>();
+            foreach (BattleKillAuditRecord record in killRecords)
+            {
+                if (record == null) throw new ArgumentException("Kill records cannot contain null.", nameof(killRecords));
+                if (!string.Equals(record.BattleSessionId, session.BattleSessionId, StringComparison.Ordinal))
+                    throw new ArgumentException("Kill records must belong to the summarized session.", nameof(killRecords));
+                if (!uniqueRecords.ContainsKey(record.RuntimeKey))
+                    uniqueRecords.Add(record.RuntimeKey, record);
+            }
+
+            List<BattleKillAuditRecord> orderedRecords = uniqueRecords.Values
+                .OrderBy(record => record.RuntimeKey)
+                .ToList();
+            var seedById = seeds.ToDictionary(seed => seed.PlayerId, StringComparer.Ordinal);
+            foreach (BattleKillAuditRecord record in orderedRecords)
+            {
+                if (!seedById.ContainsKey(record.KillerPlayerId))
+                    throw new ArgumentException("Every killer must exist in the player summary.", nameof(killRecords));
+            }
+
+            var players = new List<BattlePlayerSummary>(seeds.Count);
+            foreach (BattlePlayerSummarySeed seed in seeds)
+            {
+                int kills = orderedRecords.Count(record => string.Equals(record.KillerPlayerId, seed.PlayerId, StringComparison.Ordinal));
+                int bossKills = orderedRecords.Count(record =>
+                    string.Equals(record.KillerPlayerId, seed.PlayerId, StringComparison.Ordinal)
+                    && record.LanePolicy == BattleMonsterLanePolicy.BOSS_SHARED);
+                players.Add(new BattlePlayerSummary(seed, kills, bossKills));
+            }
+
+            var byMonster = orderedRecords
+                .GroupBy(record => record.MonsterId, StringComparer.Ordinal)
+                .OrderBy(group => group.Key, StringComparer.Ordinal)
+                .Select(group => new BattleMonsterKillSummary(group.Key, group.Count()))
+                .ToList()
+                .AsReadOnly();
+            var runtimeKeys = orderedRecords.Select(record => record.RuntimeKey).ToList().AsReadOnly();
+            var byLane = Enum.GetValues(typeof(BattleMonsterLanePolicy))
+                .Cast<BattleMonsterLanePolicy>()
+                .OrderBy(policy => (int)policy)
+                .Select(policy => new BattleLaneKillSummary(policy, orderedRecords.Count(record => record.LanePolicy == policy)))
+                .ToList()
+                .AsReadOnly();
+
+            return new BattleSummary(
+                session,
+                result,
+                finalWave,
+                players.AsReadOnly(),
+                new BattleKillSummary(byMonster, runtimeKeys, byLane));
+        }
+    }
+}

--- a/Client/Assets/Scripts/Battle/Runtime/BattleSummary.cs.meta
+++ b/Client/Assets/Scripts/Battle/Runtime/BattleSummary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dbf0e2a43bdc98a4cb71aa4c3d12af37

--- a/Client/Assets/Scripts/Battle/Wave/BattleWaveExecutor.cs
+++ b/Client/Assets/Scripts/Battle/Wave/BattleWaveExecutor.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using MyDefense.Battle.Balance;
 using MyDefense.Battle.Balance.Canonical;
+using MyDefense.Battle.Runtime;
 using MyDefense.Shared.Contracts;
 using Object = UnityEngine.Object;
 
@@ -77,6 +78,9 @@ namespace MyDefense.Battle
         private float _activeBossTimeLimitSeconds;
         private int _monsterWarningThreshold = 80;
         private int _monsterDangerThreshold = 90;
+        private BattleSessionContext _runtimeSession;
+        private IBattlePlayerIdentityProvider _playerIdentityProvider;
+        private BattleSpawnSequenceIssuer _spawnSequenceIssuer;
 
         public LaneType LocalPlayerLane => _localPlayerLane;
 
@@ -125,6 +129,7 @@ namespace MyDefense.Battle
         public string CanonicalContentHash => (_battleBalanceProvider as ICanonicalCompositeBattleBalanceProvider)?.CanonicalContentHash;
         public string BattleContentVersion => (_battleBalanceProvider as ICanonicalCompositeBattleBalanceProvider)?.BattleContentVersion;
         public string BattleContentHash => (_battleBalanceProvider as ICanonicalCompositeBattleBalanceProvider)?.BattleContentHash;
+        public BattleSessionContext RuntimeSession => _runtimeSession;
 
         private void Awake()
         {
@@ -161,6 +166,9 @@ namespace MyDefense.Battle
         {
             StopSessionCoroutines();
             ReleaseCurrentBoss();
+            _runtimeSession = null;
+            _playerIdentityProvider = null;
+            _spawnSequenceIssuer = null;
             if (Instance == this)
             {
                 Instance = null;
@@ -254,6 +262,59 @@ namespace MyDefense.Battle
             _monsterPrefabResolver = prefabResolver;
             _balanceInitializationAttempted = false;
             _isFaulted = false;
+        }
+
+        private bool EnsureRuntimeSessionReady()
+        {
+            if (_runtimeSession == null || _spawnSequenceIssuer == null || _playerIdentityProvider == null)
+            {
+                FaultExecution(
+                    "Battle runtime session must be injected before a wave can start. "
+                    + "Use InitializeSession(BattleSessionContext, IBattlePlayerIdentityProvider).");
+                return false;
+            }
+
+            string player1Id;
+            string player2Id;
+            if (!_playerIdentityProvider.TryGetPlayerId(LaneType.Player1Lane, out player1Id)
+                || string.IsNullOrWhiteSpace(player1Id)
+                || !_playerIdentityProvider.TryGetPlayerId(LaneType.Player2Lane, out player2Id)
+                || string.IsNullOrWhiteSpace(player2Id)
+                || string.Equals(player1Id, player2Id, StringComparison.Ordinal))
+            {
+                FaultExecution("Battle player identity provider must resolve two distinct, non-empty player IDs.");
+                return false;
+            }
+
+            if (_battleBalanceProvider is ICanonicalCompositeBattleBalanceProvider canonical
+                && (!string.Equals(_runtimeSession.CanonicalBalanceVersion, canonical.CanonicalBalanceVersion, StringComparison.Ordinal)
+                    || !string.Equals(_runtimeSession.CanonicalContentHash, canonical.CanonicalContentHash, StringComparison.Ordinal)
+                    || !string.Equals(_runtimeSession.BattleContentVersion, canonical.BattleContentVersion, StringComparison.Ordinal)
+                    || !string.Equals(_runtimeSession.BattleContentHash, canonical.BattleContentHash, StringComparison.Ordinal)))
+            {
+                FaultExecution("Injected Battle session balance version/hash does not match the loaded canonical bundle.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private static void ValidatePlayerIdentityProvider(IBattlePlayerIdentityProvider playerIdentityProvider)
+        {
+            if (playerIdentityProvider == null) throw new ArgumentNullException(nameof(playerIdentityProvider));
+
+            string player1Id;
+            string player2Id;
+            if (!playerIdentityProvider.TryGetPlayerId(LaneType.Player1Lane, out player1Id)
+                || string.IsNullOrWhiteSpace(player1Id)
+                || !playerIdentityProvider.TryGetPlayerId(LaneType.Player2Lane, out player2Id)
+                || string.IsNullOrWhiteSpace(player2Id)
+                || string.Equals(player1Id, player2Id, StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    "Player identity provider must resolve two distinct, non-empty player IDs.",
+                    nameof(playerIdentityProvider));
+            }
         }
 
         private void FaultExecution(string reason)
@@ -449,6 +510,37 @@ namespace MyDefense.Battle
 
         public void InitializeSession()
         {
+            if (_runtimeSession != null)
+            {
+                throw new InvalidOperationException(
+                    "Reinitializing a runtime Battle session requires a new BattleSessionContext.");
+            }
+
+            _playerIdentityProvider = null;
+            _spawnSequenceIssuer = null;
+            ResetSessionState();
+        }
+
+        public void InitializeSession(
+            BattleSessionContext sessionContext,
+            IBattlePlayerIdentityProvider playerIdentityProvider)
+        {
+            if (sessionContext == null) throw new ArgumentNullException(nameof(sessionContext));
+            ValidatePlayerIdentityProvider(playerIdentityProvider);
+            if (_runtimeSession != null
+                && string.Equals(_runtimeSession.BattleSessionId, sessionContext.BattleSessionId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Session reinitialization requires a new battleSessionId.");
+            }
+
+            _runtimeSession = sessionContext;
+            _playerIdentityProvider = playerIdentityProvider;
+            _spawnSequenceIssuer = new BattleSpawnSequenceIssuer();
+            ResetSessionState();
+        }
+
+        private void ResetSessionState()
+        {
             StopSessionCoroutines();
             ReleaseCurrentBoss();
             _currentRound = 0;
@@ -492,7 +584,8 @@ namespace MyDefense.Battle
 
         private void Start()
         {
-            InitializeSession();
+            if (_runtimeSession == null)
+                InitializeSession();
 
             if (!EnsureBalanceInitialized())
             {
@@ -604,6 +697,7 @@ namespace MyDefense.Battle
             if (!EnsureBalanceInitialized()) return false;
             if (_matchState != MatchState.RUNNING) return false;
             if (CheckGameOverState()) return false;
+            if (!EnsureRuntimeSessionReady()) return false;
 
             if (AreAllPlayersEliminated)
             {
@@ -958,6 +1052,7 @@ namespace MyDefense.Battle
             out GameObject spawnedInstance)
         {
             spawnedInstance = null;
+            if (!EnsureRuntimeSessionReady()) return false;
             if (definition == null)
             {
                 FaultExecution("Cannot spawn a null MonsterDefinition.");
@@ -996,6 +1091,44 @@ namespace MyDefense.Battle
                 return false;
             }
 
+            int runtimeContextCount = prefab.GetComponents<BattleMonsterRuntimeContext>().Length;
+            if (runtimeContextCount != 1)
+            {
+                FaultExecution(
+                    $"Prefab '{prefab.name}' for monsterId '{definition.MonsterId}' must contain exactly one "
+                    + $"BattleMonsterRuntimeContext, but found {runtimeContextCount}.");
+                return false;
+            }
+
+            BattleMonsterLanePolicy runtimeLanePolicy;
+            string fieldOwnerPlayerId;
+            if (lane == LaneType.BossSharedLane)
+            {
+                runtimeLanePolicy = BattleMonsterLanePolicy.BOSS_SHARED;
+                fieldOwnerPlayerId = null;
+            }
+            else
+            {
+                runtimeLanePolicy = BattleMonsterLanePolicy.EACH_FIELD;
+                if (!_playerIdentityProvider.TryGetPlayerId(lane, out fieldOwnerPlayerId)
+                    || string.IsNullOrWhiteSpace(fieldOwnerPlayerId))
+                {
+                    FaultExecution($"Player identity provider cannot resolve owner for lane '{lane}'.");
+                    return false;
+                }
+            }
+
+            ulong spawnSequence;
+            try
+            {
+                spawnSequence = _spawnSequenceIssuer.IssueNext();
+            }
+            catch (OverflowException exception)
+            {
+                FaultExecution(exception.Message);
+                return false;
+            }
+
             spawnedInstance = Instantiate(prefab, _spawnPoint.position, Quaternion.identity);
             if (spawnedInstance == null)
             {
@@ -1005,6 +1138,28 @@ namespace MyDefense.Battle
             }
 
             float resolvedMoveSpeed = definition.MoveSpeed * spawn.MoveSpeedMultiplier;
+            float resolvedMaxHp = definition.BaseMaxHp * spawn.HpMultiplier;
+            BattleMonsterRuntimeContext runtimeContext = spawnedInstance.GetComponent<BattleMonsterRuntimeContext>();
+            try
+            {
+                runtimeContext.Initialize(new BattleMonsterRuntimeIdentity(
+                    _runtimeSession,
+                    spawnSequence,
+                    definition.MonsterId,
+                    runtimeLanePolicy,
+                    fieldOwnerPlayerId,
+                    _currentRound,
+                    spawnSequence));
+            }
+            catch (Exception exception)
+            {
+                DestroySpawnedInstance(spawnedInstance);
+                spawnedInstance = null;
+                FaultExecution(
+                    $"Runtime context initialization failed for monsterId '{definition.MonsterId}': {exception.Message}");
+                return false;
+            }
+
             if (!TryConfigureSpawnedMovement(spawnedInstance, lane, resolvedMoveSpeed))
             {
                 spawnedInstance = null;
@@ -1012,7 +1167,6 @@ namespace MyDefense.Battle
             }
 
             MonsterStat stat = spawnedInstance.GetComponent<MonsterStat>();
-            float resolvedMaxHp = definition.BaseMaxHp * spawn.HpMultiplier;
             stat.InitializeHp(resolvedMaxHp);
             stat.InitializeBattleContext(lane, definition.CountsTowardLaneLimit);
             spawnedInstance.transform.localScale = Vector3.one * scale;


### PR DESCRIPTION
## 작업 개요

Battle Runtime의 Monster 식별자, Spawn Sequence, Kill Dedup 및 Battle Summary 기반 모델을 추가합니다.

## 주요 변경

- `BattleSessionContext` 추가
- Session별 결정적 `Spawn Sequence` 구현
- `runtimeMonsterId = spawnSequence` 정책 적용
- Runtime 중복 키 `(battleSessionId, runtimeMonsterId)` 구현
- `BattleMonsterRuntimeContext`를 Monster Prefab에 연결
- 일반 Monster의 Field Owner 정보 보존
- `BOSS_SHARED` Boss에 팀 전체 단일 Runtime ID 부여
- Kill 중복 방지 기반 모델 추가
- Player/Monster/Lane별 Battle Summary 기반 모델 추가
- BattleWaveExecutor Spawn 경로에 Runtime Context 연결

## Runtime Context 필드

- `battleSessionId`
- `runtimeMonsterId`
- `monsterId`
- `lanePolicy`
- `fieldOwnerPlayerId`
- `spawnWave`
- `spawnSequence`
- `canonicalBalanceVersion`
- `canonicalContentHash`

## 정책

- Spawn Sequence는 Session별 1부터 단조 증가
- 실패한 Spawn에 발급된 Sequence도 재사용하지 않음
- `EACH_FIELD` Monster는 Field Owner 필수
- `BOSS_SHARED` Boss는 Field Owner 없음
- 플레이어가 탈락해도 기존 Monster의 Owner는 유지
- Boss Runtime Context와 Runtime ID는 팀 전체에 1개
- 같은 Runtime Key의 Kill은 최초 1회만 등록

## 검증 결과

- 기존 Battle 테스트: 205/205 PASS
- 신규 테스트: 16/16 PASS
- 전체 EditMode: 221/221 PASS
- Unity C# 컴파일 오류: 0
- 신규 코드 Warning: 0
- Round 1 일반 Monster Context 20개 확인
- Runtime ID 1~20 유일성 확인
- P1/P2 Field Owner 각각 10개 확인
- BOSS_SHARED Context 및 Runtime ID 1개 확인
- Boss 처치 및 Timeout 회귀 테스트 PASS
- Battle Scene Missing Script/Reference: 0/0
- Monster Prefab Missing Script/Reference: 0/0

## 이번 PR에서 제외

- 실제 Monster 사망 Event 연결
- `DamagePayload.attackerPlayerId`
- 실제 Kill Gold 계산 및 지급
- Fusion Networked State/RPC
- `MonsterStat.cs` 변경
- `DamagePayload` 변경
- `GameManager.cs` 변경
- legacy `/game/enemy/kill` 삭제
- `/api/game/finish` Settlement 연결
- Targeting 및 Skill/Projectile Runtime

## Domain Impact

- Battle Domain: Runtime Monster Identity 및 Spawn Context 추가
- Shared Domain: 변경 없음
- User/System Domain: 변경 없음
- Server: 변경 없음

## 기존 변경 보존

기존 dirty 파일은 이번 커밋에 포함하지 않았습니다.

- `MonsterStat.cs`
- `UnitAttack.cs`
- Packages/ProjectSettings
- Shared Mutation/StatCalculator
- Game Design 문서
- `.agents`, `.codex`

## 알려진 후속 작업

1. `DamagePayload.attackerPlayerId` 공통 계약
2. `MonsterDeathEvent`
3. 신규 Battle의 legacy Kill API 차단
4. TASK 11C Fusion Gold Authority
5. TASK 11D 최종 Summary 및 Settlement Snapshot
6. Monster Threat Progress 및 결정적 Targeting

## 브랜치

- Source: `feature/battle-11b-runtime-identity`
- Target: `dev`
- Commit: `8463ade9fb2c145218bd8f6244b9b471734ec263`